### PR TITLE
Watch memory

### DIFF
--- a/Managers/IMemoryManager.cs
+++ b/Managers/IMemoryManager.cs
@@ -8,6 +8,7 @@ namespace MemoryManagement.Managers
         public string ReadString(IntPtr address, Encoding encoding, int maxLength = 512);
         public string[] ReadStringArray(IntPtr address, Encoding encoding, int maxLength = 512);
         public T Read<T>(IntPtr address);
+        public byte[] ReadData(IntPtr address, int dataLength);
         public T[] ReadArray<T>(IntPtr address, int arrayLength);
         public void WriteString(IntPtr address, string text, Encoding encoding);
         public void Write<T>(IntPtr address, T value);

--- a/Managers/LinuxMemoryManager.cs
+++ b/Managers/LinuxMemoryManager.cs
@@ -70,6 +70,17 @@ namespace MemoryManagement.Managers
             freeingMemory(value);
             return temp;
         }
+
+        public byte[] ReadData(IntPtr address, int dataLength)
+        {
+            IntPtr value = ReadMemory(p.Id, address, dataLength);
+            byte[] dataBuffer = new byte[dataLength];
+            Marshal.Copy(value, dataBuffer, 0, dataBuffer.Length);
+
+            freeingMemory(value);
+            return dataBuffer;
+        }
+
         //Basic implementation, leave for Zackmon someday :)
         public T[] ReadArray<T>(IntPtr address, int arrayLength)
         {

--- a/Managers/MemoryManager.cs
+++ b/Managers/MemoryManager.cs
@@ -22,6 +22,7 @@ namespace MemoryManagement
         }
 
         public T Read<T>(IntPtr address) => m.Read<T>(address);
+        public byte[] ReadData(IntPtr address, int dataLength) => m.ReadData(address, dataLength);
         public T[] ReadArray<T>(IntPtr address, int arrayLength) => m.ReadArray<T>(address, arrayLength);
 
         public string ReadString(IntPtr address, Encoding encoding, int maxLength = 512) => m.ReadString(address, encoding, maxLength);

--- a/Managers/WindowsMemoryManager.cs
+++ b/Managers/WindowsMemoryManager.cs
@@ -39,6 +39,13 @@ namespace MemoryManagement.Managers
             return MarshalType<T>.ByteArrayToObject(dataBuffer);
         }
 
+        public byte[] ReadData(IntPtr address, int dataLength)
+        {
+            byte[] dataBuffer = new byte[dataLength];
+            ReadProcessMemory(p.Handle, address, dataBuffer, dataBuffer.Length, out IntPtr bytesRead);
+            return dataBuffer;
+        }
+
         public T[] ReadArray<T>(IntPtr address, int arrayLength)
         {
             int typeSize = MarshalType<T>.Size;

--- a/Monitors/IMemoryMonitor.cs
+++ b/Monitors/IMemoryMonitor.cs
@@ -1,0 +1,11 @@
+﻿namespace MemoryManagement.Monitors
+{
+    public interface IMemoryMonitor<TEventArgs> where TEventArgs: EventArgs
+    {
+        event EventHandler<TEventArgs>? MemoryChanged;
+        void StartMonitoring();
+        Task StartMonitoringAsync(CancellationToken cancellationToken);
+        void StopMonitoring();
+        public void SetNewAddress(IntPtr newAddress);
+    }
+}

--- a/Monitors/MemoryArrayChangedEventArgs.cs
+++ b/Monitors/MemoryArrayChangedEventArgs.cs
@@ -1,0 +1,16 @@
+﻿namespace MemoryManagement.Monitors
+{
+    public class MemoryArrayChangedEventArgs<T> : EventArgs
+    {
+        public IntPtr Address { get; }
+        public T Value { get; }
+        public int Index { get; }
+
+        public MemoryArrayChangedEventArgs(IntPtr address, T value, int index)
+        {
+            Address = address;
+            Value = value;
+            Index = index;
+        }
+    }
+}

--- a/Monitors/MemoryChangedEventArgs.cs
+++ b/Monitors/MemoryChangedEventArgs.cs
@@ -1,0 +1,14 @@
+﻿namespace MemoryManagement.Monitors
+{
+    public class MemoryChangedEventArgs<T> : EventArgs
+    {
+        public IntPtr Address { get; }
+        public T Value { get; }
+
+        public MemoryChangedEventArgs(IntPtr address, T value)
+        {
+            Address = address;
+            Value = value;
+        }
+    }
+}

--- a/Monitors/MemoryMonitor.cs
+++ b/Monitors/MemoryMonitor.cs
@@ -1,0 +1,119 @@
+﻿using MemoryManagement.Managers;
+
+namespace MemoryManagement.Monitors
+{
+    /// <summary>
+    /// Monitors a specific region of memory and captures the changes as a byte array.
+    /// </summary>
+    public class MemoryMonitor : IMemoryMonitor<MemoryChangedEventArgs<byte[]>>, IDisposable
+    {
+        /// <summary>
+        /// Event that is raised when the monitored memory region changes.
+        /// </summary>
+        public event EventHandler<MemoryChangedEventArgs<byte[]>>? MemoryChanged;
+
+        private IntPtr address;
+        private IMemoryManager memoryManager;
+        private int regionSize;
+        private byte[] previousData;
+        private int pollingRate;
+        private bool isMonitoring;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemoryMonitorFromPointer"/> class.
+        /// </summary>
+        /// <param name="memoryManager">The <see cref="IMemoryManager"/> used to read memory.</param>
+        /// <param name="pointerAddress">The pointer address to the start of the monitored memory region.</param>
+        /// <param name="regionSize">The size of the monitored memory region in bytes.</param>
+        /// <param name="pointerOffset">The offset from the pointer's value to the start of the monitored memory region.</param>
+        /// <param name="pollingRateInMilliseconds">The interval between memory checks in milliseconds.</param>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="memoryManager"/> is null.</exception>
+        public MemoryMonitor(IMemoryManager memoryManager, IntPtr address, int regionSize, int pollingRateInMilliseconds = 10)
+        {
+            if (memoryManager is null)
+                throw new ArgumentException("MemoryManager must not be null.", nameof(memoryManager));
+
+            this.address = address;
+            this.memoryManager = memoryManager;
+            this.regionSize = regionSize;
+            previousData = new byte[regionSize];
+            pollingRate = pollingRateInMilliseconds;
+            isMonitoring = false;
+        }
+
+        void OnMemoryChanged(IntPtr address, byte[] value)
+        {
+            MemoryChangedEventArgs<byte[]> args = new MemoryChangedEventArgs<byte[]>(address, value);
+            MemoryChanged?.Invoke(this, args);
+        }
+
+        /// <summary>
+        /// Starts monitoring the memory region for changes synchronously.
+        /// </summary>
+        public void StartMonitoring()
+        {
+            if (isMonitoring || memoryManager is null) return;
+            isMonitoring = true;
+
+            while (address != IntPtr.Zero && isMonitoring)
+            {
+                byte[] currentData = memoryManager.ReadData(address, regionSize);
+                if (!previousData.SequenceEqual(currentData))
+                {
+                    OnMemoryChanged(address, currentData);
+                    previousData = currentData;
+                }
+                Thread.Sleep(pollingRate);
+            }
+            isMonitoring = false;
+        }
+
+        /// <summary>
+        /// Starts monitoring the memory region for changes asynchronously.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token used to stop monitoring.</param>
+        public async Task StartMonitoringAsync(CancellationToken cancellationToken)
+        {
+            if (isMonitoring) return;
+            isMonitoring = true;
+
+            while (address != IntPtr.Zero && isMonitoring)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                byte[] currentData = memoryManager.ReadData(address, regionSize);
+                if (!previousData.SequenceEqual(currentData))
+                {
+                    OnMemoryChanged(address, currentData);
+                    previousData = currentData;
+                }
+                await Task.Delay(pollingRate, cancellationToken);
+            }
+
+            isMonitoring = false;
+        }
+
+        /// <summary>
+        /// Stops monitoring the memory region.
+        /// </summary>
+        public void StopMonitoring()
+        {
+            isMonitoring = false;
+        }
+
+        /// <summary>
+        /// Sets a new address for the monitored memory region.
+        /// </summary>
+        /// <param name="newAddress">The new address to set.</param>
+        public void SetNewAddress(IntPtr newAddress) => address = newAddress;
+
+        /// <summary>
+        /// Disposes the memory monitor and stops monitoring the memory region.
+        /// </summary>
+        public void Dispose()
+        {
+            StopMonitoring();
+            MemoryChanged = null;
+        }
+    }
+}

--- a/Monitors/MemoryMonitorFromPointer.cs
+++ b/Monitors/MemoryMonitorFromPointer.cs
@@ -1,0 +1,130 @@
+﻿using MemoryManagement.Managers;
+
+namespace MemoryManagement.Monitors
+{
+    /// <summary>
+    /// Monitors a specific region of memory pointed to by a pointer and captures the changes as a byte array.
+    /// </summary>
+    public class MemoryMonitorFromPointer : IMemoryMonitor<MemoryChangedEventArgs<byte[]>>, IDisposable
+    {
+        /// <summary>
+        /// Event that is raised when the monitored memory region changes.
+        /// </summary>
+        public event EventHandler<MemoryChangedEventArgs<byte[]>>? MemoryChanged;
+
+        private IntPtr pointerAddress;
+        private IMemoryManager memoryManager;
+        private int pointerOffset;
+        private int regionSize;
+        private byte[] previousData;
+        private int pollingRate;
+        private bool isMonitoring;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemoryMonitorFromPointer"/> class.
+        /// </summary>
+        /// <param name="memoryManager">The <see cref="IMemoryManager"/> used to read memory.</param>
+        /// <param name="pointerAddress">The address of the pointer pointing to the start of the memory region.</param>
+        /// <param name="regionSize">The size of the memory region to monitor.</param>
+        /// <param name="pointerOffset">The offset from the pointer value to the start of the memory region.</param>
+        /// <param name="pollingRateInMilliseconds">The interval between memory checks in milliseconds.</param>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="memoryManager"/> is null.</exception>
+        public MemoryMonitorFromPointer(IMemoryManager memoryManager, IntPtr pointerAddress, int regionSize, int pointerOffset = 0, int pollingRateInMilliseconds = 10)
+        {
+            if (memoryManager is null)
+                throw new ArgumentException("MemoryManager must not be null.", nameof(memoryManager));
+
+            this.pointerAddress = pointerAddress;
+            this.memoryManager = memoryManager;
+            this.pointerOffset = pointerOffset;
+            this.regionSize = regionSize;
+            previousData = new byte[regionSize];
+            pollingRate = pollingRateInMilliseconds;
+            isMonitoring = false;
+        }
+
+        void OnMemoryChanged(IntPtr address, byte[] value)
+        {
+            MemoryChangedEventArgs<byte[]> args = new MemoryChangedEventArgs<byte[]>(address, value);
+            MemoryChanged?.Invoke(this, args);
+        }
+
+        /// <summary>
+        /// Starts monitoring the memory region for changes synchronously.
+        /// </summary>
+        public void StartMonitoring()
+        {
+            if (isMonitoring || memoryManager is null) return;
+            isMonitoring = true;
+
+            while (pointerAddress != IntPtr.Zero && isMonitoring)
+            {
+                IntPtr currentPointerValue = memoryManager.Read<IntPtr>(pointerAddress);
+                if (currentPointerValue != IntPtr.Zero)
+                {
+                    byte[] currentData = memoryManager.ReadData(currentPointerValue + pointerOffset, regionSize);
+                    if (!previousData.SequenceEqual(currentData))
+                    {
+                        OnMemoryChanged(currentPointerValue + pointerOffset, currentData);
+                        previousData = currentData;
+                    }
+                }
+                Thread.Sleep(pollingRate);
+            }
+
+            isMonitoring = false;
+        }
+
+        /// <summary>
+        /// Starts monitoring the memory region for changes asynchronously.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token used to stop monitoring.</param>
+        public async Task StartMonitoringAsync(CancellationToken cancellationToken)
+        {
+            if (isMonitoring) return;
+            isMonitoring = true;
+
+            while (pointerAddress != IntPtr.Zero && isMonitoring)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                IntPtr currentPointerValue = memoryManager.Read<IntPtr>(pointerAddress);
+                if (currentPointerValue != IntPtr.Zero)
+                {
+                    byte[] currentData = memoryManager.ReadData(currentPointerValue + pointerOffset, regionSize);
+                    if (!previousData.SequenceEqual(currentData))
+                    {
+                        OnMemoryChanged(currentPointerValue + pointerOffset, currentData);
+                        previousData = currentData;
+                    }
+                }
+                await Task.Delay(pollingRate, cancellationToken);
+            }
+
+            isMonitoring = false;
+
+        }
+
+        /// <summary>
+        /// Stops monitoring the memory region.
+        /// </summary>
+        public void StopMonitoring()
+        {
+            isMonitoring = false;
+        }
+
+        /// <summary>
+        /// Sets a new pointer address for the monitored memory region.
+        /// </summary>
+        /// <param name="newAddress">The new address to set.</param>
+        public void SetNewAddress(IntPtr newAddress) => pointerAddress = newAddress;
+
+        /// <summary>
+        /// Disposes the memory monitor and stops monitoring the memory region.
+        /// </summary>
+        public void Dispose()
+        {
+            StopMonitoring();
+            MemoryChanged = null;
+        }
+    }
+}

--- a/Monitors/MemoryMonitorOfT.cs
+++ b/Monitors/MemoryMonitorOfT.cs
@@ -1,0 +1,119 @@
+﻿using MemoryManagement.Internals;
+using MemoryManagement.Managers;
+
+namespace MemoryManagement.Monitors
+{
+    /// <summary>
+    /// Monitors a specific region of memory and captures the changes as the specified type T.
+    /// </summary>
+    /// <typeparam name="T">The type of data to monitor.</typeparam>
+    public class MemoryMonitor<T> : IMemoryMonitor<MemoryChangedEventArgs<T>>, IDisposable
+    {
+        /// <summary>
+        /// Event that is raised when the monitored memory region changes.
+        /// </summary>
+        public event EventHandler<MemoryChangedEventArgs<T>>? MemoryChanged;
+
+        private IntPtr address;
+        private IMemoryManager memoryManager;
+        private int dataSize;
+        private byte[] previousData;
+        private int pollingRate;
+        private bool isMonitoring;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemoryMonitor{T}"/> class.
+        /// </summary>
+        /// <param name="memoryManager">The <see cref="IMemoryManager"/> used to read memory.</param>
+        /// <param name="address">The starting address of the monitored memory region.</param>
+        /// <param name="pollingRateInMilliseconds">The interval between memory checks in milliseconds.</param>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="memoryManager"/> is null.</exception>
+        public MemoryMonitor(IMemoryManager memoryManager, IntPtr address, int pollingRateInMilliseconds = 10)
+        {
+            if (memoryManager is null)
+                throw new ArgumentException("MemoryManager must not be null.", nameof(memoryManager));
+
+            this.address = address;
+            this.memoryManager = memoryManager;
+            dataSize = MarshalType<T>.Size;
+            previousData = new byte[dataSize];
+            pollingRate = pollingRateInMilliseconds;
+            isMonitoring = false;
+        }
+
+        void OnMemoryChanged(IntPtr address, T value)
+        {
+            MemoryChangedEventArgs<T> args = new MemoryChangedEventArgs<T>(address, value);
+            MemoryChanged?.Invoke(this, args);
+        }
+
+        /// <summary>
+        /// Starts monitoring the memory region for changes synchronously.
+        /// </summary>
+        public void StartMonitoring()
+        {
+            if (isMonitoring || memoryManager is null) return;
+            isMonitoring = true;
+
+            while (address != IntPtr.Zero && isMonitoring)
+            {
+                byte[] currentData = memoryManager.ReadData(address, dataSize);
+                if (!previousData.SequenceEqual(currentData))
+                {
+                    OnMemoryChanged(address, MarshalType<T>.ByteArrayToObject(currentData));
+                    previousData = currentData;
+                }
+                Thread.Sleep(pollingRate);
+            }
+            isMonitoring = false;
+        }
+
+        /// <summary>
+        /// Starts monitoring the memory region for changes asynchronously.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token used to stop monitoring.</param>
+        public async Task StartMonitoringAsync(CancellationToken cancellationToken)
+        {
+            if (isMonitoring) return;
+            isMonitoring = true;
+
+            while (address != IntPtr.Zero && isMonitoring)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                byte[] currentData = memoryManager.ReadData(address, dataSize);
+                if (!previousData.SequenceEqual(currentData))
+                {
+                    OnMemoryChanged(address, MarshalType<T>.ByteArrayToObject(currentData));
+                    previousData = currentData;
+                }
+                await Task.Delay(pollingRate, cancellationToken);
+            }
+
+            isMonitoring = false;
+        }
+
+        /// <summary>
+        /// Stops monitoring the memory region.
+        /// </summary>
+        public void StopMonitoring()
+        {
+            isMonitoring = false;
+        }
+
+        /// <summary>
+        /// Sets a new address for the monitored memory region.
+        /// </summary>
+        /// <param name="newAddress">The new address to set.</param>
+        public void SetNewAddress(IntPtr newAddress) => address = newAddress;
+
+        /// <summary>
+        /// Disposes the memory monitor and stops monitoring the memory region.
+        /// </summary>
+        public void Dispose()
+        {
+            StopMonitoring();
+            MemoryChanged = null;
+        }
+    }
+}

--- a/Monitors/MemoryMonitorOfTFromPointer.cs
+++ b/Monitors/MemoryMonitorOfTFromPointer.cs
@@ -1,0 +1,131 @@
+﻿using MemoryManagement.Internals;
+using MemoryManagement.Managers;
+
+namespace MemoryManagement.Monitors
+{
+    /// <summary>
+    /// Monitors a specific region of memory pointed to by a pointer and captures the changes as the specified type T.
+    /// </summary>
+    /// <typeparam name="T">The type of the memory value.</typeparam>
+    public class MemoryMonitorFromPointer<T> : IMemoryMonitor<MemoryChangedEventArgs<T>>, IDisposable
+    {
+        /// <summary>
+        /// Event that is raised when the monitored memory location changes.
+        /// </summary>
+        public event EventHandler<MemoryChangedEventArgs<T>>? MemoryChanged;
+
+        private IntPtr pointerAddress;
+        private IMemoryManager memoryManager;
+        private int pointerOffset;
+        private int dataSize;
+        private byte[] previousData;
+        private int pollingRate;
+        private bool isMonitoring;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemoryMonitorFromPointer{T}"/> class.
+        /// </summary>
+        /// <param name="memoryManager">The <see cref="IMemoryManager"/> used to read memory.</param>
+        /// <param name="pointerAddress">The address of the pointer that points to the monitored memory location.</param>
+        /// <param name="pointerOffset">The offset from the pointer value to the monitored memory location.</param>
+        /// <param name="pollingRateInMilliseconds">The interval between memory checks in milliseconds.</param>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="memoryManager"/> is null.</exception>
+        public MemoryMonitorFromPointer(IMemoryManager memoryManager, IntPtr pointerAddress, int pointerOffset = 0, int pollingRateInMilliseconds = 10)
+        {
+            if (memoryManager is null)
+                throw new ArgumentException("MemoryManager must not be null.", nameof(memoryManager));
+
+            this.pointerAddress = pointerAddress;
+            this.memoryManager = memoryManager;
+            this.pointerOffset = pointerOffset;
+            dataSize = MarshalType<T>.Size;
+            previousData = new byte[dataSize];
+            pollingRate = pollingRateInMilliseconds;
+            isMonitoring = false;
+        }
+
+        void OnMemoryChanged(IntPtr address, T value)
+        {
+            MemoryChangedEventArgs<T> args = new MemoryChangedEventArgs<T>(address, value);
+            MemoryChanged?.Invoke(this, args);
+        }
+
+        /// <summary>
+        /// Starts monitoring the memory region for changes synchronously.
+        /// </summary>
+        public void StartMonitoring()
+        {
+            if (isMonitoring || memoryManager is null) return;
+            isMonitoring = true;
+
+            while (pointerAddress != IntPtr.Zero && isMonitoring)
+            {
+                IntPtr currentPointerValue = memoryManager.Read<IntPtr>(pointerAddress);
+                if (currentPointerValue != IntPtr.Zero)
+                {
+                    byte[] currentData = memoryManager.ReadData(currentPointerValue + pointerOffset, dataSize);
+                    if (!previousData.SequenceEqual(currentData))
+                    {
+                        OnMemoryChanged(currentPointerValue + pointerOffset, MarshalType<T>.ByteArrayToObject(currentData));
+                        previousData = currentData;
+                    }
+                }
+                Thread.Sleep(pollingRate);
+            }
+
+            isMonitoring = false;
+        }
+
+        /// <summary>
+        /// Starts monitoring the memory region for changes asynchronously.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token used to stop monitoring.</param>
+        public async Task StartMonitoringAsync(CancellationToken cancellationToken)
+        {
+            if (isMonitoring) return;
+            isMonitoring = true;
+
+            while (pointerAddress != IntPtr.Zero && isMonitoring)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                IntPtr currentPointerValue = memoryManager.Read<IntPtr>(pointerAddress);
+                if (currentPointerValue != IntPtr.Zero)
+                {
+                    byte[] currentData = memoryManager.ReadData(currentPointerValue + pointerOffset, dataSize);
+                    if (!previousData.SequenceEqual(currentData))
+                    {
+                        OnMemoryChanged(currentPointerValue + pointerOffset, MarshalType<T>.ByteArrayToObject(currentData));
+                        previousData = currentData;
+                    }
+                }
+                await Task.Delay(pollingRate, cancellationToken);
+            }
+
+            isMonitoring = false;
+
+        }
+
+        /// <summary>
+        /// Stops monitoring the memory region.
+        /// </summary>
+        public void StopMonitoring()
+        {
+            isMonitoring = false;
+        }
+
+        /// <summary>
+        /// Sets a new pointer address for the monitored memory region.
+        /// </summary>
+        /// <param name="newAddress">The new address to set.</param>
+        public void SetNewAddress(IntPtr newAddress) => pointerAddress = newAddress;
+
+        /// <summary>
+        /// Disposes the memory monitor and stops monitoring the memory region.
+        /// </summary>
+        public void Dispose()
+        {
+            StopMonitoring();
+            MemoryChanged = null;
+        }
+    }
+}

--- a/Monitors/MemoryMonitorTArray.cs
+++ b/Monitors/MemoryMonitorTArray.cs
@@ -1,0 +1,132 @@
+﻿using MemoryManagement.Internals;
+using MemoryManagement.Managers;
+
+namespace MemoryManagement.Monitors
+{
+    /// <summary>
+    /// Monitors a specific array of T elements in memory and captures the changes as the specified type T.
+    /// </summary>
+    /// <typeparam name="T">The type of elements in the array.</typeparam>
+    public class MemoryMonitorTArray<T> : IMemoryMonitor<MemoryArrayChangedEventArgs<T>>, IDisposable
+    {
+        /// <summary>
+        /// Event that is raised when the monitored memory array changes.
+        /// </summary>
+        public event EventHandler<MemoryArrayChangedEventArgs<T>>? MemoryChanged;
+
+        private IntPtr address;
+        private IMemoryManager memoryManager;
+        private int dataSize;
+        private int arrayLength;
+        private byte[] previousData;
+        private int pollingRate;
+        private bool isMonitoring;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemoryMonitorTArray{T}"/> class.
+        /// </summary>
+        /// <param name="memoryManager">The <see cref="IMemoryManager"/> used to read memory.</param>
+        /// <param name="address">The address of the memory array.</param>
+        /// <param name="arrayLength">The number of <see cref="T"/> objects in the memory array.</param>
+        /// <param name="pollingRateInMilliseconds">The interval between memory checks in milliseconds.</param>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="memoryManager"/> is null or <paramref name="arrayLength"/> is not greater than 0.</exception>
+        public MemoryMonitorTArray(IMemoryManager memoryManager, IntPtr address, int arrayLength, int pollingRateInMilliseconds = 10)
+        {
+            if (memoryManager is null)
+                throw new ArgumentException("MemoryManager must not be null.", nameof(memoryManager));
+
+            if (arrayLength <= 0)
+                throw new ArgumentException("The array length must be a positive value.", nameof(arrayLength));
+
+            this.address = address;
+            this.memoryManager = memoryManager;
+            dataSize = MarshalType<T>.Size;
+            this.arrayLength = arrayLength;
+            previousData = new byte[arrayLength * dataSize];
+            pollingRate = pollingRateInMilliseconds;
+            isMonitoring = false;
+        }
+
+        void OnMemoryChanged(IntPtr address, T value, int index)
+        {
+            MemoryArrayChangedEventArgs<T> args = new MemoryArrayChangedEventArgs<T>(address, value, index);
+            MemoryChanged?.Invoke(this, args);
+        }
+
+        /// <summary>
+        /// Starts monitoring the memory array for changes synchronously.
+        /// </summary>
+        public void StartMonitoring()
+        {
+            if (isMonitoring || memoryManager is null) return;
+            isMonitoring = true;
+
+            while (address != IntPtr.Zero && isMonitoring)
+            {
+                for (int i = 0; i < arrayLength; i++)
+                {
+                    int startIndex = i * dataSize;
+
+                    byte[] currentData = memoryManager.ReadData(address + startIndex, dataSize);
+                    if (!previousData.AsSpan(startIndex, dataSize).SequenceEqual(currentData))
+                    {
+                        OnMemoryChanged(address, MarshalType<T>.ByteArrayToObject(currentData), i);
+                        currentData.CopyTo(previousData, startIndex);
+                    }
+                }
+                Thread.Sleep(pollingRate);
+            }
+            isMonitoring = false;
+        }
+
+        /// <summary>
+        /// Starts monitoring the memory array for changes asynchronously.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token used to stop monitoring.</param>
+        public async Task StartMonitoringAsync(CancellationToken cancellationToken)
+        {
+            if (isMonitoring) return;
+            isMonitoring = true;
+
+            while (address != IntPtr.Zero && isMonitoring)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                for (int i = 0; i < arrayLength; i++)
+                {
+                    byte[] currentData = memoryManager.ReadData(address + i * dataSize, dataSize);
+                    if (!previousData[(i * dataSize)..((i + i) * dataSize)].SequenceEqual(currentData))
+                    {
+                        OnMemoryChanged(address, MarshalType<T>.ByteArrayToObject(currentData), i);
+                        Array.Copy(currentData, 0, previousData, i * dataSize, dataSize);
+                    }
+                }
+                await Task.Delay(pollingRate, cancellationToken);
+            }
+
+            isMonitoring = false;
+        }
+
+        /// <summary>
+        /// Stops monitoring the memory array.
+        /// </summary>
+        public void StopMonitoring()
+        {
+            isMonitoring = false;
+        }
+
+        /// <summary>
+        /// Sets a new pointer address for the monitored memory array.
+        /// </summary>
+        /// <param name="newAddress">The new pointer address to set.</param>
+        public void SetNewAddress(IntPtr newAddress) => address = newAddress;
+
+        /// <summary>
+        /// Disposes the memory monitor and stops monitoring the memory array.
+        /// </summary>
+        public void Dispose()
+        {
+            StopMonitoring();
+            MemoryChanged = null;
+        }
+    }
+}

--- a/Monitors/MemoryMonitorTArrayFromPointer.cs
+++ b/Monitors/MemoryMonitorTArrayFromPointer.cs
@@ -1,0 +1,145 @@
+﻿using MemoryManagement.Internals;
+using MemoryManagement.Managers;
+
+namespace MemoryManagement.Monitors
+{
+    /// <summary>
+    /// Monitors a specific array of T elements in memory, pointed to by a pointer, and captures the changes as the specified type T.
+    /// </summary>
+    /// <typeparam name="T">The type of elements in the array.</typeparam>
+    public class MemoryMonitorTArrayFromPointer<T> : IMemoryMonitor<MemoryArrayChangedEventArgs<T>>, IDisposable
+    {
+        /// <summary>
+        /// Event that is raised when the monitored memory array changes.
+        /// </summary>
+        public event EventHandler<MemoryArrayChangedEventArgs<T>>? MemoryChanged;
+
+        private IntPtr pointerAddress;
+        private IMemoryManager memoryManager;
+        private int pointerOffset;
+        private int dataSize;
+        private int arrayLength;
+        private byte[] previousData;
+        private int pollingRate;
+        private bool isMonitoring;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MemoryMonitorTArrayFromPointer{T}"/> class.
+        /// </summary>
+        /// <param name="memoryManager">The <see cref="IMemoryManager"/> used to read memory.</param>
+        /// <param name="pointerAddress">The addres of the pointer that is pointing to the start of the memory array.</param>
+        /// <param name="arrayLength">The number of <see cref="T"/> objects in the memory array.</param>
+        /// <param name="pointerOffset">The offset from the pointer value to the start of the array.</param>
+        /// <param name="pollingRateInMilliseconds">The interval between memory checks in milliseconds.</param>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="memoryManager"/> is null or <paramref name="arrayLength"/> is not greater than 0.</exception>
+        public MemoryMonitorTArrayFromPointer(IMemoryManager memoryManager, IntPtr pointerAddress, int arrayLength, int pointerOffset = 0, int pollingRateInMilliseconds = 10)
+        {
+            if (memoryManager is null)
+                throw new ArgumentException("MemoryManager must not be null.", nameof(memoryManager));
+
+            if (arrayLength <= 0)
+                throw new ArgumentException("The array length must be a positive value.", nameof(arrayLength));
+
+            this.pointerAddress = pointerAddress;
+            this.memoryManager = memoryManager;
+            this.pointerOffset = pointerOffset;
+            this.arrayLength = arrayLength;
+            dataSize = MarshalType<T>.Size;
+            previousData = new byte[dataSize * arrayLength];
+            pollingRate = pollingRateInMilliseconds;
+            isMonitoring = false;
+        }
+
+        void OnMemoryChanged(IntPtr address, T value, int index)
+        {
+            MemoryArrayChangedEventArgs<T> args = new MemoryArrayChangedEventArgs<T>(address, value, index);
+            MemoryChanged?.Invoke(this, args);
+        }
+
+        /// <summary>
+        /// Starts monitoring the memory array for changes synchronously.
+        /// </summary>
+        public void StartMonitoring()
+        {
+            if (isMonitoring) return;
+            isMonitoring = true;
+
+            while (pointerAddress != IntPtr.Zero && isMonitoring)
+            {
+                IntPtr currentPointerValue = memoryManager.Read<IntPtr>(pointerAddress);
+                if (currentPointerValue != IntPtr.Zero)
+                {
+                    for (int i = 0; i < arrayLength; i++)
+                    {
+                        int startIndex = i * dataSize;
+
+                        byte[] currentData = memoryManager.ReadData(currentPointerValue + pointerOffset + startIndex, dataSize);
+                        if (!previousData.AsSpan(startIndex, dataSize).SequenceEqual(currentData))
+                        {
+                            OnMemoryChanged(currentPointerValue, MarshalType<T>.ByteArrayToObject(currentData), i);
+                            currentData.CopyTo(previousData, startIndex);
+                        }
+                    }
+                }
+                Thread.Sleep(pollingRate);
+            }
+
+            isMonitoring = false;
+        }
+
+        /// <summary>
+        /// Starts monitoring the memory array for changes asynchronously.
+        /// </summary>
+        /// <param name="cancellationToken">The cancellation token used to stop monitoring.</param>
+        public async Task StartMonitoringAsync(CancellationToken cancellationToken)
+        {
+            if (isMonitoring) return;
+            isMonitoring = true;
+
+            while (pointerAddress != IntPtr.Zero && isMonitoring)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                IntPtr currentPointerValue = memoryManager.Read<IntPtr>(pointerAddress);
+                if (currentPointerValue != IntPtr.Zero)
+                {
+                    for (int i = 0; i < arrayLength; i++)
+                    {
+                        byte[] currentData = memoryManager.ReadData(currentPointerValue + pointerOffset + i * dataSize, dataSize);
+                        if (!previousData[(i * dataSize)..((i + i) * dataSize)].SequenceEqual(currentData))
+                        {
+                            OnMemoryChanged(currentPointerValue, MarshalType<T>.ByteArrayToObject(currentData), i);
+                            Array.Copy(currentData, 0, previousData, i * dataSize, dataSize);
+                        }
+                    }
+                }
+                await Task.Delay(pollingRate, cancellationToken);
+            }
+
+            isMonitoring = false;
+
+        }
+
+        /// <summary>
+        /// Stops monitoring the memory array.
+        /// </summary>
+        public void StopMonitoring()
+        {
+            isMonitoring = false;
+        }
+
+        /// <summary>
+        /// Sets a new pointer address for the monitored memory array.
+        /// </summary>
+        /// <param name="newAddress">The new pointer address to set.</param>
+        public void SetNewAddress(IntPtr newAddress) => pointerAddress = newAddress;
+
+        /// <summary>
+        /// Disposes the memory monitor and stops monitoring the memory array.
+        /// </summary>
+        public void Dispose()
+        {
+            StopMonitoring();
+            MemoryChanged = null;
+        }
+    }
+}


### PR DESCRIPTION
Implemented 6 kinds of MemoryMonitors that can watch a region in memory for changes and raise events when data in that region is changed.

Non-generic monitors that send raw byte arrays in the EventArgs, generic monitors that marshal data into a specific type, and generic array monitors that watch an array of objects and raises events for individual elements.

Monitors can used from a permanent address or from a pointer plus offset that points to the region of memory that you want to monitor.